### PR TITLE
Fix checkbox at safari

### DIFF
--- a/src/ui/BaseUI.js
+++ b/src/ui/BaseUI.js
@@ -75,9 +75,7 @@ export class BaseUI {
         item.setAttribute("id","node-container-" + id);
         item.innerHTML = '\
             <div style="display: inline-flex; width: calc(100% - 105px)">\
-                <div id="input-select-'+ id +'" style="flex-grow: 1;">\
-                    <input type="checkbox" id="' + prefix + id +'" style="flex: 15px;">\
-                </div>\
+                <input type="checkbox" id="' + prefix + id +'" style="flex: 15px;">\
                 <span style="width: 100%; margin-left: 10px;">\
                     '+ label +'\
                 </span>\


### PR DESCRIPTION
On safari the checkbox itself is not clickable. It's overlapped by the label. See attached Screenshot.

<img width="267" alt="checkbox-safari" src="https://user-images.githubusercontent.com/5708253/216682247-c7671040-701f-49f0-9b1f-2691fd98eefa.png">

For me it looks like that the id selector input-select-id of the parent div was never used and was wrongly taken from the uiSelectInput. I just removed the parent div entirely which fixes safari. 